### PR TITLE
aligned docs with apis of v0.0.9

### DIFF
--- a/docs/user-guide/configuration/config/config.md
+++ b/docs/user-guide/configuration/config/config.md
@@ -9,8 +9,8 @@ metadata:
   name: dev1-interface-system0
   namespace: default
   labels:
-    targetName: dev1
-    targetNamespace: default
+    config.sdcio.dev/targetName: dev1
+    config.sdcio.dev/targetNamespace: default
 spec:
   priority: 10
   config:

--- a/docs/user-guide/configuration/schemas.md
+++ b/docs/user-guide/configuration/schemas.md
@@ -12,16 +12,38 @@ The Schema CustomResource is configured using three main parameter groups:
 
 ## Source of Schema: Repository Configuration
 
-To successfully retrieve the schema, it is essential for users to provide three key parameters: `repoURL`, `kind`, and `ref`.
+To successfully retrieve the schema, it is essential for users to provide four key parameters: `repoURL`, `kind`, `ref` and `credentials`.
 These parameters jointly establish the methodology for schema acquisition:
 
 * `repoURL`: This parameter is pivotal as it specifies the repository's URL where the schema is located.
 * `kind`: It determines the nature of the reference point within the repository, offering options between a "tag" or a "branch".
 * `ref`: This parameter is closely linked to kind and pinpoints the exact tag or branch name within the repository.
+* `credentials`: This parameter is point to a secret name in the same namespace as the `schema` CR. It is required if your repository requires authentication e.g. a private repo.
 
 Following the identification of schema directories and files for download, the `dirs` attribute plays a crucial role. It allows users to map each source directory to a corresponding local storage location. Essentially, dirs is an array comprising pairs of `src` (source directory) and `dst` (destination path). This setup facilitates the organization of downloaded schema files, ensuring they are stored in designated local directories for easy access and management.
 
 If the dirs attribute is not set, it defaults to `$pwd` for both `src` and `dst`.
+
+## Repository authentication
+
+If your schema repository requires authentication a secret of type `kubernetes.io/basic-auth` is referenced in the schema CR. An Example of such secret is provided below.
+
+!!!note "username/password"
+  Please fill out your own username and password/token
+
+!!!note "namespace"
+  The secret MUST use the same namespace as the schema CR that is referencing it.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: personal-access-token
+data:
+  password: <e.g. personal access token>
+  username: <your username>
+type: kubernetes.io/basic-auth
+```
 
 ## Schema Identification: Naming Conventions
 

--- a/docs/user-guide/configuration/schemas.md
+++ b/docs/user-guide/configuration/schemas.md
@@ -40,8 +40,8 @@ kind: Secret
 metadata:
   name: personal-access-token
 data:
-  password: <e.g. personal access token>
-  username: <your username>
+  username: <base64-encoded-username>
+  password: <base64-encoded-password>
 type: kubernetes.io/basic-auth
 ```
 

--- a/docs/user-guide/configuration/target-profiles/connection-profile.md
+++ b/docs/user-guide/configuration/target-profiles/connection-profile.md
@@ -25,6 +25,7 @@ For connections via NETCONF, the `protocol` needs to be set to `netconf`. Specif
 * `operationWithNS`: Activates proper namespacing for the `edit-config` RPC operation attribute in NETCONF.
 * `useOperationRemove`: If set to true, SDC utilizes the NETCONF operation `remove` rather than `delete`.
 * `preferredNetconfVersion`: Selects between NETCONF versions `1.0` or `1.1`.
+* `commitCandidate`: Selects the datastore on the target for applying the config to. Defaults to `candidate`, but can be set to `running` if the target does not support a `candidate` datastore.
 
 ```yaml
 apiVersion: inv.sdcio.dev/v1alpha1


### PR DESCRIPTION
Why?

updating the docs with the api changes that were done in v0.0.9.
- fix: target reference in config CR
- added credentials in schema for repository authentication
- added commitCandidate in connection profile to allow specifying a running datastore.